### PR TITLE
Make sure continuations are called only once in Relay code

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,11 @@ NostrKit can be used to publish events on a Nostr relay as well as request event
 
 ``` swift
 let keyPair = try KeyPair(privateKey: "<hex>")
-let relay = Relay(url: URL("<url>")!, onEvent: { print($0) })
+let relay = Relay(url: URL("<url>")!, 
+                  onEvent: { print($0) },
+                  onDisconnect: { error in 
+                      // Handle reconnecting here if needed
+                  })
 
 let subscription = Subscription(filters: [
     .init(authors: [keyPair.publicKey])

--- a/README.md
+++ b/README.md
@@ -19,11 +19,7 @@ NostrKit can be used to publish events on a Nostr relay as well as request event
 
 ``` swift
 let keyPair = try KeyPair(privateKey: "<hex>")
-let relay = Relay(url: URL("<url>")!, 
-                  onEvent: { print($0) },
-                  onDisconnect: { error in 
-                      // Handle reconnecting here if needed
-                  })
+let relay = Relay(url: URL("<url>")!, onEvent: { print($0) })
 
 let subscription = Subscription(filters: [
     .init(authors: [keyPair.publicKey])

--- a/Sources/NostrKit/Event.swift
+++ b/Sources/NostrKit/Event.swift
@@ -8,7 +8,7 @@ public enum EventError: Error {
     case signingFailed
 }
 
-public enum EventKind: Codable {
+public enum EventKind: Codable, Equatable {
     case setMetadata
     case textNote
     case recommentServer

--- a/Sources/NostrKit/EventFilter.swift
+++ b/Sources/NostrKit/EventFilter.swift
@@ -1,13 +1,13 @@
 import Foundation
 
 public struct EventFilter: Encodable {
-    let ids: [EventId]?
-    let authors: [String]?
-    let eventKinds: [EventKind]?
-    let tags: [String: [String]]?
-    let since: Timestamp?
-    let until: Timestamp?
-    let limit: Int?
+    public let ids: [EventId]?
+    public let authors: [String]?
+    public let eventKinds: [EventKind]?
+    public let tags: [String: [String]]?
+    public let since: Timestamp?
+    public let until: Timestamp?
+    public let limit: Int?
     
     private enum CodingKeys: String, CodingKey {
         case ids

--- a/Sources/NostrKit/Relay.swift
+++ b/Sources/NostrKit/Relay.swift
@@ -76,7 +76,7 @@ public struct Relay {
                     continuation.resume(throwing: RelayError.writeError(error))
                 }
             } else {
-                continuation.resume()
+                continuation.resume(throwing: RelayError.socketError(nil))
             }
         }
     }

--- a/Sources/NostrKit/Relay.swift
+++ b/Sources/NostrKit/Relay.swift
@@ -38,10 +38,6 @@ public struct Relay {
             }
             
             socket.onConnect = {
-                socket.onDisconnect = { error in
-                    continuation.resume(with: .failure(RelayError.socketError(error)))
-                }
-                
                 continuation.resume()
             }
             


### PR DESCRIPTION
Hey! I believe I have fixed the issues I found where the sockets would crash after some time when the socket was disconnected. I hope Im not stepping on your toes. Just wanted to contribute what has fixed the issues for me so far :)

Basically, in the connect function where it was using the async wrapping function, continuation was being called multiple times. I removed that handled on disconnect a bit differently.

Also, I removed the async wrapping function from disconnect as the onDisconnect closure was already being handled in the connect function.